### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Creates video project from images project",
-  "docker_image": "supervisely/data-operations:6.73.525",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.15.40",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   ],
   "description": "Creates video project from images project",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely==6.73.486
+supervisely==6.73.564
 scikit-image>=0.26.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
